### PR TITLE
Add Visual Studio folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# visual studio directories
+
+.vs


### PR DESCRIPTION
Visual Studio creates a folder (.vs) in the parent directory. It's not part of the project.